### PR TITLE
Added Support for Multiple Containers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,7 +53,7 @@ $(element).patchpanel({
  
 ### Multiple patch-containers
 
- Patch-Panel can support having multiple containers and having them nested inside of each other. In order to use this feature, give your patch containers a unique ID, as done in the examples below. Note that this does not change how you initiailze the containers, just initialize by the container class (with `$(".patch-container").patchpanel();`).
+ Patch-Panel can support having multiple containers and having them nested inside of each other. In order to use this feature, give your patch containers a unique ID, as done in the examples below. Note that this does not change how you initiailze the containers, just initialize by the container class with `$(".patch-container").patchpanel();`.
 
 * One after the other
 ```HTML

--- a/README.markdown
+++ b/README.markdown
@@ -35,67 +35,67 @@ npm install patch-panel
 
 #### Initialization Example
 
-````javascript
+```javascript
 $(element).patchpanel({
   toggleSpeed: 600
 });
-````
+```
 
 #### Gotchas
 
 * All elements are automatically hidden upon initialization with jQuery. Since there's a delay between the DOM loading and javascript initializing, the panels may flicker from visible to hidden. You can avoid this by placing the following in your stylesheet:
 
-````javascript
+```CSS
 .patch-panel {
   display: none;
 }
-````
+```
  
 ### Multiple patch-containers
 
- Patch-Panel can support having multiple containers and having them nested inside eachother.
+ Patch-Panel can support having multiple containers and having them nested inside of each other.
 
  One after the other
-````
- <div id = "a" class = "patch-container">
-     <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
-     <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button</div>
-     <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
-     <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
-     <div class="patch-panel" data-patch-panel="2">1.2 panel</div>
-     <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
- </div>
- <br>
- <div id = "b" class = "patch-container">
-     <div class="patch-item patch-button" data-patch-panel="1">2.1 button</div>
-     <div class="patch-item patch-button" data-patch-panel="2">2.2 button</div>
-     <div class="patch-item patch-button" data-patch-panel="3">2.3 button</div>
-     <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
-     <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
-     <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
- </div>
-````
+```HTML
+<div id = "a" class = "patch-container">
+  <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
+  <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button</div>
+  <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
+  <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
+  <div class="patch-panel" data-patch-panel="2">1.2 panel</div>
+  <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
+</div>
+<br>
+<div id = "b" class = "patch-container">
+  <div class="patch-item patch-button" data-patch-panel="1">2.1 button</div>
+  <div class="patch-item patch-button" data-patch-panel="2">2.2 button</div>
+  <div class="patch-item patch-button" data-patch-panel="3">2.3 button</div>
+  <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
+  <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
+  <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
+</div>
+```
  One nested in the other
-````
- <div id = "a" class = "patch-container">
-     <div class="patch-item patch-button" data-patch-panel="1">1.1 button</div>
-     <div class="patch-item patch-button" data-patch-panel="2">1.2 button (Nested)</div>
-     <div class="patch-item patch-button" data-patch-panel="3">1.3 button</div>
-     <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
-     <div class="patch-panel" data-patch-panel="2">
-         1.2 panel
-         <div id = "b" class = "patch-container">
-             <div class="patch-item patch-button" data-patch-panel="1">2.1 button</div>
-             <div class="patch-item patch-button" data-patch-panel="2">2.2 button</div>
-             <div class="patch-item patch-button" data-patch-panel="3">2.3 button</div>
-             <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
-             <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
-             <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
-         </div>
-     </div>
-     <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
- </div>
-````
+```HTML
+<div id = "a" class = "patch-container">
+  <div class="patch-item patch-button" data-patch-panel="1">1.1 button</div>
+  <div class="patch-item patch-button" data-patch-panel="2">1.2 button (Nested)</div>
+  <div class="patch-item patch-button" data-patch-panel="3">1.3 button</div>
+  <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
+  <div class="patch-panel" data-patch-panel="2">
+    1.2 panel
+    <div id = "b" class = "patch-container">
+      <div class="patch-item patch-button" data-patch-panel="1">2.1 button</div>
+      <div class="patch-item patch-button" data-patch-panel="2">2.2 button</div>
+      <div class="patch-item patch-button" data-patch-panel="3">2.3 button</div>
+      <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
+      <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
+      <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
+    </div>
+  </div>
+  <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
+</div>
+```
 #### Future Updates
 
 * Better handling of events so that only two panels are triggered at any one time.

--- a/README.markdown
+++ b/README.markdown
@@ -53,9 +53,9 @@ $(element).patchpanel({
  
 ### Multiple patch-containers
 
- Patch-Panel can support having multiple containers and having them nested inside of each other.
+ Patch-Panel can support having multiple containers and having them nested inside of each other. In order to use this feature, give your patch containers a unique ID, as done in the examples below. Note that this does not change how you initiailze the containers, just initialize by the container class (with `$(".patch-container").patchpanel();`).
 
- One after the other
+* One after the other
 ```HTML
 <div id = "a" class = "patch-container">
   <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
@@ -75,7 +75,7 @@ $(element).patchpanel({
   <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
 </div>
 ```
- One nested in the other
+* One nested in the other
 ```HTML
 <div id = "a" class = "patch-container">
   <div class="patch-item patch-button" data-patch-panel="1">1.1 button</div>

--- a/README.markdown
+++ b/README.markdown
@@ -11,87 +11,7 @@ http://patchpanel.alecortega.com
 
 ![alt tag](http://oi61.tinypic.com/sp8axi.jpg)
  
-#### Multiple patch-containers
 
- One after the other
-````
- <div id = "a" class = "patch-container">
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button</div>
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
- 
-     <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
- 
-     <div class="patch-panel" data-patch-panel="2">1.2 panel</div>
- 
-     <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
- 
- </div>
- 
- <br>
- 
- <div id = "b" class = "patch-container">
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="1">2.1 button</div>
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="2">2.2 button</div>
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="3">2.3 button</div>
- 
-     <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
- 
-     <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
- 
-     <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
- 
- </div>
- 
-````
- 
- One nested in the other
-````
- <div id = "a" class = "patch-container">
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button (Nested)</div>
- 
-     <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
- 
-    
-     <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
- 
-     <div class="patch-panel" data-patch-panel="2">
- 
-         1.2 panel
- 
-         <div id = "b" class = "patch-container">
- 
-             <div class="navfield patch-item patch-button" data-patch-panel="1">2.1 button</div>
-
-             <div class="navfield patch-item patch-button" data-patch-panel="2">2.2 button</div>
- 
-             <div class="navfield patch-item patch-button" data-patch-panel="3">2.3 button</div>
- 
-            
-             <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
- 
-             <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
- 
-             <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
- 
-         </div>
- 
-     </div>
- 
-     <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
- 
- </div>
- 
-````
 
 #### Package Managers
 
@@ -131,8 +51,49 @@ $(element).patchpanel({
 }
 ````
  
- 
+ #### Multiple patch-containers
 
+ One after the other
+````
+ <div id = "a" class = "patch-container">
+     <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
+     <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button</div>
+     <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
+     <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
+     <div class="patch-panel" data-patch-panel="2">1.2 panel</div>
+     <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
+ </div>
+ <br>
+ <div id = "b" class = "patch-container">
+     <div class="navfield patch-item patch-button" data-patch-panel="1">2.1 button</div>
+     <div class="navfield patch-item patch-button" data-patch-panel="2">2.2 button</div>
+     <div class="navfield patch-item patch-button" data-patch-panel="3">2.3 button</div>
+     <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
+     <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
+     <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
+ </div>
+````
+ One nested in the other
+````
+ <div id = "a" class = "patch-container">
+     <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
+     <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button (Nested)</div>
+     <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
+     <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
+     <div class="patch-panel" data-patch-panel="2">
+         1.2 panel
+         <div id = "b" class = "patch-container">
+             <div class="navfield patch-item patch-button" data-patch-panel="1">2.1 button</div>
+             <div class="navfield patch-item patch-button" data-patch-panel="2">2.2 button</div>
+             <div class="navfield patch-item patch-button" data-patch-panel="3">2.3 button</div>
+             <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
+             <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
+             <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
+         </div>
+     </div>
+     <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
+ </div>
+````
 #### Future Updates
 
 * Better handling of events so that only two panels are triggered at any one time.

--- a/README.markdown
+++ b/README.markdown
@@ -35,11 +35,11 @@ npm install patch-panel
 
 #### Initialization Example
 
-```javascript
+````javascript
 $(element).patchpanel({
   toggleSpeed: 600
 });
-```
+````
 
 #### Gotchas
 
@@ -51,7 +51,9 @@ $(element).patchpanel({
 }
 ````
  
- #### Multiple patch-containers
+### Multiple patch-containers
+
+ Patch-Panel can support having multiple containers and having them nested inside eachother.
 
  One after the other
 ````
@@ -65,9 +67,9 @@ $(element).patchpanel({
  </div>
  <br>
  <div id = "b" class = "patch-container">
-     <div class="navfield patch-item patch-button" data-patch-panel="1">2.1 button</div>
-     <div class="navfield patch-item patch-button" data-patch-panel="2">2.2 button</div>
-     <div class="navfield patch-item patch-button" data-patch-panel="3">2.3 button</div>
+     <div class="patch-item patch-button" data-patch-panel="1">2.1 button</div>
+     <div class="patch-item patch-button" data-patch-panel="2">2.2 button</div>
+     <div class="patch-item patch-button" data-patch-panel="3">2.3 button</div>
      <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
      <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
      <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
@@ -76,16 +78,16 @@ $(element).patchpanel({
  One nested in the other
 ````
  <div id = "a" class = "patch-container">
-     <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
-     <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button (Nested)</div>
-     <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
+     <div class="patch-item patch-button" data-patch-panel="1">1.1 button</div>
+     <div class="patch-item patch-button" data-patch-panel="2">1.2 button (Nested)</div>
+     <div class="patch-item patch-button" data-patch-panel="3">1.3 button</div>
      <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
      <div class="patch-panel" data-patch-panel="2">
          1.2 panel
          <div id = "b" class = "patch-container">
-             <div class="navfield patch-item patch-button" data-patch-panel="1">2.1 button</div>
-             <div class="navfield patch-item patch-button" data-patch-panel="2">2.2 button</div>
-             <div class="navfield patch-item patch-button" data-patch-panel="3">2.3 button</div>
+             <div class="patch-item patch-button" data-patch-panel="1">2.1 button</div>
+             <div class="patch-item patch-button" data-patch-panel="2">2.2 button</div>
+             <div class="patch-item patch-button" data-patch-panel="3">2.3 button</div>
              <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
              <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
              <div class="patch-panel" data-patch-panel="3">2.3 panel</div>

--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,88 @@ Patch Panel makes responsive grid + panel layouts possible by displaying the cor
 http://patchpanel.alecortega.com
 
 ![alt tag](http://oi61.tinypic.com/sp8axi.jpg)
+ 
+#### Multiple patch-containers
+
+ One after the other
+````
+ <div id = "a" class = "patch-container">
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button</div>
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
+ 
+     <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
+ 
+     <div class="patch-panel" data-patch-panel="2">1.2 panel</div>
+ 
+     <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
+ 
+ </div>
+ 
+ <br>
+ 
+ <div id = "b" class = "patch-container">
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="1">2.1 button</div>
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="2">2.2 button</div>
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="3">2.3 button</div>
+ 
+     <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
+ 
+     <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
+ 
+     <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
+ 
+ </div>
+ 
+````
+ 
+ One nested in the other
+````
+ <div id = "a" class = "patch-container">
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="1">1.1 button</div>
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="2">1.2 button (Nested)</div>
+ 
+     <div class="navfield patch-item patch-button" data-patch-panel="3">1.3 button</div>
+ 
+    
+     <div class="patch-panel" data-patch-panel="1">1.1 panel</div>
+ 
+     <div class="patch-panel" data-patch-panel="2">
+ 
+         1.2 panel
+ 
+         <div id = "b" class = "patch-container">
+ 
+             <div class="navfield patch-item patch-button" data-patch-panel="1">2.1 button</div>
+
+             <div class="navfield patch-item patch-button" data-patch-panel="2">2.2 button</div>
+ 
+             <div class="navfield patch-item patch-button" data-patch-panel="3">2.3 button</div>
+ 
+            
+             <div class="patch-panel" data-patch-panel="1">2.1 panel</div>
+ 
+             <div class="patch-panel" data-patch-panel="2">2.2 panel</div>
+ 
+             <div class="patch-panel" data-patch-panel="3">2.3 panel</div>
+ 
+         </div>
+ 
+     </div>
+ 
+     <div class="patch-panel" data-patch-panel="3">1.3 panel</div>
+ 
+ </div>
+ 
+````
 
 #### Package Managers
 
@@ -48,6 +130,8 @@ $(element).patchpanel({
   display: none;
 }
 ````
+ 
+ 
 
 #### Future Updates
 

--- a/src/patchpanel.js
+++ b/src/patchpanel.js
@@ -8,77 +8,33 @@
  */
 (function($, window, document, undefined) {
 
-  "use strict";
-
-  // Create the defaults once
-  var pluginName = "patchpanel",
-    defaults = {
-      buttonSelector: ".patch-button",
-      itemSelector: ".patch-item",
-      panelSelector: ".patch-panel",
-      toggleSpeed: 300
-    };
-
-  // The actual plugin constructor
-  function Plugin(element, options) {
-    this.element = element;
-    // jQuery has an extend method which merges the contents of two or
-    // more objects, storing the result in the first object. The first object
-    // is generally empty as we don"t want to alter the default options for
-    // future instances of the plugin
-    this.settings = $.extend({}, defaults, options);
-    this._defaults = defaults;
-    this._name = pluginName;
-
-    this.init();
-  }
-
-  // Avoid Plugin.prototype conflicts
-  $.extend(Plugin.prototype, {
-    init: function() {
-      this.buildCache();
-      this.bindEvents();
-      this.initializePanels();
-    },
-
-    buildCache: function() {
-      this.$window = $(window);
-      this.$container = $(this.element);
-      this.$itemCollection = $(this.element).children(this.settings.itemSelector);
-      this.$patchButton = $(this.settings.buttonSelector);
-
-      this.windowWidth = $(window).width();
-      this.itemSelector = this.settings.itemSelector;
-      this.panelSelector = this.settings.panelSelector;
-    },
-
-    bindEvents: function() {
-      var plugin = this;
-
-      plugin.$patchButton.on("click", function(e) {
-        // Prevent default in case the button is an anchor tag
-        e.preventDefault();
-
-        var $el = $(this);
-        var $openPanel = plugin.isPanelOpen();
-        var $hiddenPanel = $(plugin.panelSelector + "[data-patch-panel=" + $el.attr("data-patch-panel") + "]");
-
-        // IF: Button clicked corresponds to a panel and no panels are already open, open panel
-        if (!$openPanel) {
-          plugin.appendPanel($el, $hiddenPanel);
-          plugin.togglePanel($hiddenPanel);
-        }
-
-        // ELSE IF: Button clicked corresponds to a panel that is already open
         else if ($openPanel.attr("data-patch-panel") === $hiddenPanel.attr("data-patch-panel")) {
-          plugin.togglePanel($openPanel);
-        }
+    "use strict";
 
-        // ELSE IF: Button clicked corresponds to a different panel and a panel is open
-        else if ($openPanel.attr("data-patch-panel") !== $hiddenPanel.attr("data-patch-panel")) {
-          plugin.appendPanel($el, $hiddenPanel);
-          plugin.togglePanel($openPanel);
-          plugin.togglePanel($hiddenPanel);
+    // Create the default selectors
+    var pluginName = "patchpanel",
+        defaults = {
+            itemSelector: ".patch-item",
+            panelSelector: ".patch-panel",
+            toggleSpeed: 300
+        };
+
+    function Plugin(element, options) {
+        this.element = element;
+        // JQuery has an extend method which merges the contents of two or
+        // more objects, storing the result in the first object. The first object
+        // is generally empty as we don't want to alter the default options for
+        // future instances of the plugin
+
+        this.settings = $.extend({}, defaults, options);
+
+        // for multiple panels modify selectors to only take relevant elements to the current list
+        if(element.hasAttribute('id')) { // Multiple containers require IDs to be given to each one for differentiation
+
+            var idSelector    = "#" + element.id; // Container ID
+            var classSelector = "#" + element.className; // Container class
+
+            // Selection requirements require the following pattern to avoid errors when there are multiple patch panels
         }
       });
 
@@ -95,59 +51,27 @@
         // Prevents resize from triggering on scroll on  mobile
         if ($openPanel && plugin.windowWidth !== plugin.$window.width()) {
           $openPanel.toggleClass("open").hide();
-          plugin.windowWidth = plugin.$window.width();
-        }
-      }, 200);
-    },
-
     appendPanel: function($button, panel) {
-      var plugin = this;
 
       // Stores the current portfolio item object
-      var $item = $button.closest(plugin.itemSelector);
+        this._name = pluginName;
 
       // Stores the index of the current item in relation to the item collection
-      var itemIndex = $(plugin.$itemCollection).index($item);
-
-      // Calculates number of items in row by dividing container width by width of item
-      var itemsInRow = Math.floor(plugin.$container.width() / $item.width());
-
       // Calculates the number of items that follow the clicked one within the row
-      var itemOffset = Math.floor(($item.position().left - 1) / $item.width());
+        this.init(); //Initializes the container by 1) Finding elements, 2) Applying events, 3) Applying formatting (closing open panels)
+    }
 
-      // Appends the panel at the items current index plus the offset
-      $(plugin.$itemCollection[itemIndex + (itemsInRow - itemOffset - 1)]).append().after(panel);
-    },
+    // Avoid Plugin.prototype conflicts
+    $.extend(Plugin.prototype, {
 
-    debounce: function(func, wait, immediate) {
-      var timeout;
-      return function() {
-        var context = this, args = arguments;
-        var later = function() {
-          timeout = null;
-          if (!immediate) func.apply(context, args);
-        };
-        var callNow = immediate && !timeout;
-        clearTimeout(timeout);
-        timeout = setTimeout(later, wait);
-        if (callNow) func.apply(context, args);
-      };
-    },
-
-    isPanelOpen: function() {
-      var $openPanel = $(this.panelSelector + ".open");
+        init: function() {
+            this.buildCache(); // Find associated elements and window properties
+            this.bindEvents(); // Apply on click events, and window resize events
+            this.initializePanels(); //set initial panel format (all closed and relative postitioned)
+        },
 
       // Returns panel object if a panel is open, else returns false
       return $openPanel.length > 0 ? $openPanel : false;
-    },
-
-    initializePanels: function() {
-      var plugin = this;
-      $(this.panelSelector).hide();
-      plugin.$container.css("position", "relative");
-    },
-
-    togglePanel: function($panel) {
       $panel.stop().toggleClass("open").slideToggle(this.settings.toggleSpeed);
     }
   });
@@ -159,7 +83,22 @@
       if (!$.data(this, "plugin_" + pluginName)) {
         $.data(this, "plugin_" + pluginName, new Plugin(this, options));
       }
+
+
+
+
+
+
+
+        isPanelOpen: function() {
+
+            var $openPanel = $(this.panelSelector + ".open");
+
+            // Returns panel object if a panel is open, else returns false
+            return $openPanel.length > 0 ? $openPanel : false;
+        },
+
+        }
     });
-  };
 
 })(jQuery, window, document);

--- a/src/patchpanel.js
+++ b/src/patchpanel.js
@@ -30,7 +30,7 @@
         this.settings = $.extend({}, defaults, options);
 
         // for multiple panels modify selectors to only take relevant elements to the current list
-        if(element.hasAttribute('id')) { // Multiple containers require IDs to be given to each one for differentiation
+        if(element.hasAttribute("id")) { // Multiple containers require IDs to be given to each one for differentiation
 
             var idSelector    = "#" + element.id; // Container ID
             var classSelector = "#" + element.className; // Container class
@@ -48,11 +48,11 @@
             //this.settings["externalPanelSelector"] = this.settings["panelSelector"]+ "[data-patch-container=" + idSelector.substring(1) + "]";
 
             // Select buttons
-            this.settings["buttonSelector"] = idSelector + ' ' + this.settings["buttonSelector"] + ':not("' + idSelector + ' ' + classSelector + ' ' + this.settings["buttonSelector"] + '")';
+            this.settings.buttonSelector = idSelector + " " + this.settings.buttonSelector + ":not(\"" + idSelector + " " + classSelector + " " + this.settings.buttonSelector + "\")";
             // Select items
-            this.settings["itemSelector"  ] = idSelector + ' ' + this.settings["itemSelector"  ] + ':not("' + idSelector + ' ' + classSelector + ' ' + this.settings["itemSelector"  ] + '")';
-            // Locate panels
-            this.settings["panelSelector" ] = idSelector + ' ' + this.settings["panelSelector" ] + ':not("' + idSelector + ' ' + classSelector + ' ' + this.settings["panelSelector" ] + '")';
+            this.settings.itemSelector   = idSelector + " " + this.settings.itemSelector   + ":not(\"" + idSelector + " " + classSelector + " " + this.settings.itemSelector   + "\")";
+            // Select panels
+            this.settings.panelSelector  = idSelector + " " + this.settings.panelSelector  + ":not(\"" + idSelector + " " + classSelector + " " + this.settings.panelSelector  + "\")";
         }
 
         this._name = pluginName;
@@ -78,7 +78,7 @@
 
             // To support external buttons the line below becomes:
             // this.$patchButton = $(this.settings.buttonSelector).add(this.settings.externalButtonSelector);
-            this.$patchButton = $(this.settings.buttonSelector)
+            this.$patchButton = $(this.settings.buttonSelector);
 
             this.windowWidth = $(window).width();
             this.itemSelector = this.settings.itemSelector;
@@ -130,7 +130,7 @@
                 }
 
                 //Prevents event bubbling on nested panels from closing the panels as soon as they are opened
-                e.stopImmediatePropagation()
+                e.stopImmediatePropagation();
             });
 
             // TODO: Refactor debounce, one level of abstraction too many

--- a/src/patchpanel.js
+++ b/src/patchpanel.js
@@ -8,17 +8,18 @@
  */
 (function($, window, document, undefined) {
 
-        else if ($openPanel.attr("data-patch-panel") === $hiddenPanel.attr("data-patch-panel")) {
     "use strict";
 
     // Create the default selectors
     var pluginName = "patchpanel",
         defaults = {
+            buttonSelector: ".patch-button",
             itemSelector: ".patch-item",
             panelSelector: ".patch-panel",
             toggleSpeed: 300
         };
 
+    // The actual plugin constructor
     function Plugin(element, options) {
         this.element = element;
         // JQuery has an extend method which merges the contents of two or
@@ -35,29 +36,28 @@
             var classSelector = "#" + element.className; // Container class
 
             // Selection requirements require the following pattern to avoid errors when there are multiple patch panels
+            // idSelector eachvalue:not("idSelector classSelector eachvalue")';
+            // i = idSelector + ' ' + i + ':not("' + idSelector + ' ' + classSelector + ' ' + i + '")';
+            // JavaScript really needs to get a function for formatting strings
+
+            // For adding support for buttons and panels located outside the container.
+            // currently enabling this breaks the appending process, but this could be fixed later, but may not make sense with the "content below the button" idea
+            // Select linked buttons located outside their panel-container
+            //this.settings["externalButtonSelector"] = this.settings["buttonSelector"]+ "[data-patch-container=" + idSelector.substring(1) + "]";
+            // Select panels located outside their panel-container
+            //this.settings["externalPanelSelector"] = this.settings["panelSelector"]+ "[data-patch-container=" + idSelector.substring(1) + "]";
+
+            // Select buttons
+            this.settings["buttonSelector"] = idSelector + ' ' + this.settings["buttonSelector"] + ':not("' + idSelector + ' ' + classSelector + ' ' + this.settings["buttonSelector"] + '")';
+            // Select items
+            this.settings["itemSelector"  ] = idSelector + ' ' + this.settings["itemSelector"  ] + ':not("' + idSelector + ' ' + classSelector + ' ' + this.settings["itemSelector"  ] + '")';
+            // Locate panels
+            this.settings["panelSelector" ] = idSelector + ' ' + this.settings["panelSelector" ] + ':not("' + idSelector + ' ' + classSelector + ' ' + this.settings["panelSelector" ] + '")';
         }
-      });
 
-      // TODO: Refactor debounce, one level of abstraction too many
-      var debouncedResize = plugin.hidePanel();
-
-      plugin.$window.on("resize", debouncedResize);
-    },
-
-    hidePanel: function() {
-      var plugin = this;
-      return plugin.debounce(function() {
-        var $openPanel = plugin.isPanelOpen();
-        // Prevents resize from triggering on scroll on  mobile
-        if ($openPanel && plugin.windowWidth !== plugin.$window.width()) {
-          $openPanel.toggleClass("open").hide();
-    appendPanel: function($button, panel) {
-
-      // Stores the current portfolio item object
         this._name = pluginName;
+        this._defaults = defaults;
 
-      // Stores the index of the current item in relation to the item collection
-      // Calculates the number of items that follow the clicked one within the row
         this.init(); //Initializes the container by 1) Finding elements, 2) Applying events, 3) Applying formatting (closing open panels)
     }
 
@@ -70,26 +70,129 @@
             this.initializePanels(); //set initial panel format (all closed and relative postitioned)
         },
 
-      // Returns panel object if a panel is open, else returns false
-      return $openPanel.length > 0 ? $openPanel : false;
-      $panel.stop().toggleClass("open").slideToggle(this.settings.toggleSpeed);
-    }
-  });
+        //Finds buttons, items, container, and window propertie for later use
+        buildCache: function() {
+            this.$window = $(window);
+            this.$container = $(this.element);
+            this.$itemCollection = $(this.element).children(this.settings.itemSelector);
 
-  // A really lightweight plugin wrapper around the constructor,
-  // preventing against multiple instantiations
-  $.fn[pluginName] = function(options) {
-    return this.each(function() {
-      if (!$.data(this, "plugin_" + pluginName)) {
-        $.data(this, "plugin_" + pluginName, new Plugin(this, options));
-      }
+            // To support external buttons the line below becomes:
+            // this.$patchButton = $(this.settings.buttonSelector).add(this.settings.externalButtonSelector);
+            this.$patchButton = $(this.settings.buttonSelector)
 
+            this.windowWidth = $(window).width();
+            this.itemSelector = this.settings.itemSelector;
+            this.panelSelector = this.settings.panelSelector;
+        },
 
+        // Controls click events on patch-buttons
+        bindEvents: function() {
+            var plugin = this;
 
+            // Called when someone clicks a patch-button
+            plugin.$patchButton.on("click", function(e) {
+                // Prevent default in case the button is an anchor tag
+                e.preventDefault();
 
+                var $el = $(this);
 
+                var $openPanel = plugin.isPanelOpen();
+                var $hiddenPanel = $(plugin.panelSelector + "[data-patch-panel=" + $el.attr("data-patch-panel") + "]").add();
 
+                // IF: Button clicked corresponds to a panel and no panels are already open, open panel
+                if (!$openPanel) {
+                    // Note: This line breaks the possibility of external buttons and panels.
+                    // Removing it fixes external buttons, but breaks the layout process
+                    plugin.appendPanel($el, $hiddenPanel);
+                    plugin.togglePanel($hiddenPanel);
+                }
 
+                // ELSE IF: Button clicked corresponds to a panel that is already open
+                else if ($openPanel.attr("data-patch-panel") === $hiddenPanel.attr("data-patch-panel")) {
+                    plugin.togglePanel($openPanel);
+                }
+
+                // ELSE IF: Button clicked corresponds to a different panel and a panel is open
+                else if ($openPanel.attr("data-patch-panel") !== $hiddenPanel.attr("data-patch-panel")) {
+
+                    // Note: This line  breaks the possibility of external buttons and panels.
+                    // Removing it fixes external buttons, but breaks the layout process
+                    plugin.appendPanel($el, $hiddenPanel);
+
+                    // To allow for nested panels, don't close panel if the panel you are opening is it's child.
+                    $openPanel.each(function () { // Iterate through open panels
+                        if (! $.contains($(this)[0], $hiddenPanel[0])) { // If the open panel is not an ascendant of the panel being hidden
+                            plugin.togglePanel($(this)); // Close it
+                        }
+                    });
+
+                    plugin.togglePanel($hiddenPanel); //open up the new panel
+                }
+
+                //Prevents event bubbling on nested panels from closing the panels as soon as they are opened
+                e.stopImmediatePropagation()
+            });
+
+            // TODO: Refactor debounce, one level of abstraction too many
+            var debouncedResize = plugin.hidePanel();  // Closes all open panels
+            plugin.$window.on("resize", debouncedResize); // Perhaps it should reopen it again afterwords?
+        },
+
+        // closes any open panels, and reidentifies window width
+        // This is called when window is resized (see binEvents::debouncedResize)
+        hidePanel: function() {
+
+            var plugin = this;
+            return plugin.debounce(function() {
+
+                var $openPanel = plugin.isPanelOpen();
+
+                // Prevents resize from triggering on scroll on  mobile
+                if ($openPanel && plugin.windowWidth !== plugin.$window.width()) {
+                    $openPanel.toggleClass("open").hide(); // Closes open panels
+                    plugin.windowWidth = plugin.$window.width(); // Finds new window with
+                }
+
+            }, 200);
+        },
+
+        // For determining size and position of panels
+        // Note: This function breaks the possibility of external buttons and panels.
+        appendPanel: function($button, panel) {
+            var plugin = this;
+
+            // Stores the current portfolio item object
+            var $item = $button.closest(plugin.itemSelector);
+
+            // Stores the index of the current item in relation to the item collection
+            var itemIndex = $(plugin.$itemCollection).index($item);
+
+            // Calculates number of items in row by dividing container width by width of item
+            var itemsInRow = Math.floor(plugin.$container.width() / $item.width());
+
+            // Calculates the number of items that follow the clicked one within the row
+            var itemOffset = Math.floor(($item.position().left - 1) / $item.width());
+
+            // Appends the panel at the items current index plus the offset
+            $(plugin.$itemCollection[itemIndex + (itemsInRow - itemOffset - 1)]).append().after(panel);
+        },
+
+        debounce: function(func, wait, immediate) {
+            var timeout;
+            return function() {
+                var context = this, args = arguments;
+                var later = function() {
+                    timeout = null;
+                    if (!immediate) func.apply(context, args);
+                };
+                var callNow = immediate && !timeout;
+                clearTimeout(timeout);
+                timeout = setTimeout(later, wait);
+                if (callNow) func.apply(context, args);
+            };
+        },
+
+        //returns all open panels, or false if there are none
         isPanelOpen: function() {
 
             var $openPanel = $(this.panelSelector + ".open");
@@ -98,7 +201,27 @@
             return $openPanel.length > 0 ? $openPanel : false;
         },
 
+        // All panels should be initialy closed, and set to relative positioning
+        initializePanels: function() {
+            var plugin = this;
+            $(this.panelSelector).hide();
+            plugin.$container.css("position", "relative");
+        },
+
+        // opens the panel if it is closed, closes it if it's open
+        togglePanel: function($panel) {
+            $panel.stop().toggleClass("open").slideToggle(this.settings.toggleSpeed);
         }
     });
+
+    // A really lightweight plugin wrapper around the constructor,
+    // preventing against multiple instantiations
+    $.fn[pluginName] = function(options) {
+        return this.each(function() {
+            if (!$.data(this, "plugin_" + pluginName)) {
+                $.data(this, "plugin_" + pluginName, new Plugin(this, options));
+            }
+        });
+    };
 
 })(jQuery, window, document);


### PR DESCRIPTION
I added support for multiple and nested patch-containers. With multiple containers, opening/closing a panel in one container has no effect on elements of other containers, even if they have the same `data-patch-panel` attribute value.

To do this, the main changes I made were:
1. I modified the selectors in settings to only select elements from the correct container.
2. Modified on click function so that it does not close a panel if the panel you are opening is it's child.
3. Modified on click function to stop event propagations so that nested container buttons do not immediately recluse from event bubbling
4. Added a section on using multiple and nested patch-containers to the README.markdown file

I also made the following changes:
1. Added additional comments
2. Fixed some code formatting in the README

I also began to implement another feature, of allowing buttons and panels to be accessed and placed outside their patch-containers by supplying an optional `data-patch-container` attribute to the button or panel to link it with it's container, but this was likely to have side effects because of the way `appendPanel` formats panel positions based on the location of the button, which did not make since in this context, and so I commented it out. 
